### PR TITLE
Allow to use Resources without interface

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,17 +1,24 @@
 {
-    "name": "daniel-de-wit/nova-single-record-resource",
+    "name": "marko298/nova-single-record-resource",
     "description": "Laravel Nova Single Record Resource. Shows a link in the navigation bar directly to the only record of the resource",
     "keywords": [
         "Laravel",
         "Nova"
     ],
-    "homepage": "https://github.com/daniel-de-wit/nova-single-record-resource",
+    "homepage": "https://github.com/marko298/nova-single-record-resource",
     "license": "MIT",
     "authors": [
         {
             "name": "Daniël de Wit",
             "email": "daniel@danieldewit.nl",
             "homepage": "https://github.com/daniel-de-wit",
+            "role": "Maintainer"
+        },
+
+        {
+            "name": "Mark Boychuk",
+            "email": "boychuk.m.n@gmail.com",
+            "homepage": "https://github.com/marko298",
             "role": "Maintainer"
         }
     ],
@@ -22,7 +29,7 @@
     },
     "autoload": {
         "psr-4": {
-            "DanielDeWit\\NovaSingleRecordResource\\": "src"
+            "Marko298\\NovaSingleRecordResource\\": "src"
         }
     },
     "autoload-dev": {
@@ -34,7 +41,7 @@
     "extra": {
         "laravel": {
             "providers": [
-                "DanielDeWit\\NovaSingleRecordResource\\Providers\\NovaSingleRecordResourceServiceProvider"
+                "Marko298\\NovaSingleRecordResource\\Providers\\NovaSingleRecordResourceServiceProvider"
             ]
         }
     },

--- a/composer.json
+++ b/composer.json
@@ -9,16 +9,15 @@
     "license": "MIT",
     "authors": [
         {
-            "name": "Daniël de Wit",
-            "email": "daniel@danieldewit.nl",
-            "homepage": "https://github.com/daniel-de-wit",
-            "role": "Maintainer"
-        },
-
-        {
             "name": "Mark Boychuk",
             "email": "boychuk.m.n@gmail.com",
             "homepage": "https://github.com/marko298",
+            "role": "Maintainer"
+        },
+        {
+            "name": "Daniël de Wit",
+            "email": "daniel@danieldewit.nl",
+            "homepage": "https://github.com/daniel-de-wit",
             "role": "Maintainer"
         }
     ],

--- a/readme.md
+++ b/readme.md
@@ -4,6 +4,8 @@
 [![Total Downloads](https://img.shields.io/packagist/dt/daniel-de-wit/nova-single-record-resource.svg?style=flat-square)](https://packagist.org/packages/daniel-de-wit/nova-single-record-resource)
 [![StyleCI](https://github.styleci.io/repos/160710362/shield?branch=master)](https://github.styleci.io/repos/160710362)
 
+### Fork of [daniel-de-wit/nova-single-record-resource](https://github.com/daniel-de-wit/nova-single-record-resource)
+
 Adds the ability to create a navigation link directly to the detail page of a resource.
 Useful for models that will contain only a single record.
 
@@ -112,7 +114,7 @@ When publishing vendor assets with the tag `nova-views` the template will be pla
 <summary>View changes</summary>
 
 ```php
-@if ($resource::singleRecord())
+@if (method_exists($resource, 'singleRecord') && $resource::singleRecord())
     <router-link :to="{
     name: 'detail',
     params: {

--- a/readme.md
+++ b/readme.md
@@ -1,15 +1,15 @@
 # Laravel Nova: Single Record Resource
-[![License](https://img.shields.io/github/license/mashape/apistatus.svg)](https://packagist.org/packages/daniel-de-wit/nova-single-record-resource)
-[![Latest Version on Packagist](https://img.shields.io/packagist/v/daniel-de-wit/nova-single-record-resource.svg?style=flat-square)](https://packagist.org/packages/daniel-de-wit/nova-single-record-resource)
-[![Total Downloads](https://img.shields.io/packagist/dt/daniel-de-wit/nova-single-record-resource.svg?style=flat-square)](https://packagist.org/packages/daniel-de-wit/nova-single-record-resource)
+[![License](https://img.shields.io/github/license/mashape/apistatus.svg)](https://packagist.org/packages/marko298/nova-single-record-resource)
+[![Latest Version on Packagist](https://img.shields.io/packagist/v/marko298/nova-single-record-resource.svg?style=flat-square)](https://packagist.org/packages/marko298/nova-single-record-resource)
+[![Total Downloads](https://img.shields.io/packagist/dt/marko298/nova-single-record-resource.svg?style=flat-square)](https://packagist.org/packages/marko298/nova-single-record-resource)
 [![StyleCI](https://github.styleci.io/repos/160710362/shield?branch=master)](https://github.styleci.io/repos/160710362)
 
-### Fork of [daniel-de-wit/nova-single-record-resource](https://github.com/daniel-de-wit/nova-single-record-resource)
+### Fork of [marko298/nova-single-record-resource](https://github.com/marko298/nova-single-record-resource)
 
 Adds the ability to create a navigation link directly to the detail page of a resource.
 Useful for models that will contain only a single record.
 
-![](https://github.com/daniel-de-wit/nova-single-record-resource/raw/master/demo.gif)
+![](https://github.com/marko298/nova-single-record-resource/raw/master/demo.gif)
 
 ## Prerequisites
  - [Laravel](https://laravel.com/)
@@ -18,7 +18,7 @@ Useful for models that will contain only a single record.
 ## Installation
 
 ```
-$ composer require daniel-de-wit/nova-single-record-resource
+$ composer require marko298/nova-single-record-resource
 ```
 
 Add  `SupportSingleRecordNavigationLinks` trait to Resources:
@@ -59,7 +59,7 @@ $ php artisan vendor:publish --force --provider="Marko298\NovaSingleRecordResour
 Remove from composer
 
 ```
-$ composer remove daniel-de-wit/nova-single-record-resource
+$ composer remove marko298/nova-single-record-resource
 ```
 
 Remove `SupportSingleRecordNavigationLinks` trait from your Nova Resources

--- a/readme.md
+++ b/readme.md
@@ -28,7 +28,7 @@ Add  `SupportSingleRecordNavigationLinks` trait to Resources:
 
 namespace App\Nova;
 
-use DanielDeWit\NovaSingleRecordResource\Traits\SupportSingleRecordNavigationLinks;
+use Marko298\NovaSingleRecordResource\Traits\SupportSingleRecordNavigationLinks;
 use Laravel\Nova\Resource as NovaResource;
 
 abstract class Resource extends NovaResource
@@ -41,7 +41,7 @@ abstract class Resource extends NovaResource
 
 Publish assets:
 ```
-$ php artisan vendor:publish --provider="DanielDeWit\NovaSingleRecordResource\Providers\NovaSingleRecordResourceServiceProvider"
+$ php artisan vendor:publish --provider="Marko298\NovaSingleRecordResource\Providers\NovaSingleRecordResourceServiceProvider"
 ```
 
 
@@ -50,7 +50,7 @@ $ php artisan vendor:publish --provider="DanielDeWit\NovaSingleRecordResource\Pr
 When updating it is important to republish the assets, like so:
 
 ```
-$ php artisan vendor:publish --force --provider="DanielDeWit\NovaSingleRecordResource\Providers\NovaSingleRecordResourceServiceProvider"
+$ php artisan vendor:publish --force --provider="Marko298\NovaSingleRecordResource\Providers\NovaSingleRecordResourceServiceProvider"
 ```
 
 

--- a/readme.md
+++ b/readme.md
@@ -21,18 +21,17 @@ Useful for models that will contain only a single record.
 $ composer require daniel-de-wit/nova-single-record-resource
 ```
 
-Modify `app/Nova/Resource.php` to implement `SingleRecordResourceInterface` and the `SupportSingleRecordNavigationLinks` trait:
+Add  `SupportSingleRecordNavigationLinks` trait to Resources:
 
 ```php
 <?php
 
 namespace App\Nova;
 
-use DanielDeWit\NovaSingleRecordResource\Contracts\SingleRecordResourceInterface;
 use DanielDeWit\NovaSingleRecordResource\Traits\SupportSingleRecordNavigationLinks;
 use Laravel\Nova\Resource as NovaResource;
 
-abstract class Resource extends NovaResource implements SingleRecordResourceInterface
+abstract class Resource extends NovaResource
 {
     use SupportSingleRecordNavigationLinks;
 

--- a/resources/views/resources/navigation.blade.php
+++ b/resources/views/resources/navigation.blade.php
@@ -15,7 +15,7 @@
         <ul class="list-reset mb-8">
             @foreach($resources as $resource)
                 <li class="leading-tight mb-4 ml-8 text-sm">
-                    @if ($resource::singleRecord())
+                    @if (method_exists($resource, 'singleRecord') && $resource::singleRecord())
                         <router-link :to="{
                             name: 'detail',
                             params: {

--- a/src/Contracts/SingleRecordResourceInterface.php
+++ b/src/Contracts/SingleRecordResourceInterface.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DanielDeWit\NovaSingleRecordResource\Contracts;
+namespace Marko298\NovaSingleRecordResource\Contracts;
 
 interface SingleRecordResourceInterface
 {

--- a/src/Providers/NovaSingleRecordResourceServiceProvider.php
+++ b/src/Providers/NovaSingleRecordResourceServiceProvider.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DanielDeWit\NovaSingleRecordResource\Providers;
+namespace Marko298\NovaSingleRecordResource\Providers;
 
 use Illuminate\Support\ServiceProvider;
 

--- a/src/Traits/SupportSingleRecordNavigationLinks.php
+++ b/src/Traits/SupportSingleRecordNavigationLinks.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DanielDeWit\NovaSingleRecordResource\Traits;
+namespace Marko298\NovaSingleRecordResource\Traits;
 
 trait SupportSingleRecordNavigationLinks
 {


### PR DESCRIPTION
If you are using Resources not extended from Nova folder one, you will receive error like this

```
Call to undefined method Vyuldashev\NovaPermission\Role::singleRecord() (View: /Users/user/project/resources/views/vendor/nova/resources/navigation.blade.php)

```

my pull request checks whether method exists, this fixes error